### PR TITLE
Fixed LM75B import error in epd.py

### DIFF
--- a/pwnagotchi/ui/hw/libs/papirus/epd.py
+++ b/pwnagotchi/ui/hw/libs/papirus/epd.py
@@ -15,7 +15,7 @@
 
 from PIL import Image
 from PIL import ImageOps
-from pwnagotchi.ui.hw.libs.papirus import LM75B
+from pwnagotchi.ui.hw.libs.papirus.lm75b import LM75B
 import re
 import os
 import sys


### PR DESCRIPTION
Fixed LM75B import error

<!--- Provide a general summary of your changes in the Title above -->

## Description
Append the missing lm75b to the import string in epd.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without the change, the pwnagotchi service fails when using a papirus screen.
<!--- If it fixes an open issue, please link to the issue here. -->
- [x ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
The pwnagotchi (with a papirus screen) correctly boots after the modification

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
